### PR TITLE
Removed autoMergeBranchPush from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["config:base", ":automergeMinor", ":automergeBranchPush"]
+  "extends": ["config:base", ":automergeMinor"]
 }


### PR DESCRIPTION
This is an attempt to allow renovate to push minor dependency updates