### PR TITLE
feat(events page): added buttons to jump to different classes of even…

### DIFF
--- a/components/Events/index.tsx
+++ b/components/Events/index.tsx
@@ -24,6 +24,7 @@ type EventProps = {
 const Events = (props: EventProps) => (
   <>
     {style(props.direction)}
+    <a id={props.type} />
     <div
       className='row mb-4'
       style={{
@@ -31,6 +32,7 @@ const Events = (props: EventProps) => (
       }}
     >
       <div className='m-auto p-2 col-sm-12 col-md-6 col-lg-4'>
+
         <h1
           className='mb-0'
           style={{ textAlign: props.direction === 'right' ? 'left' : 'right' }}

--- a/pages/events/index.tsx
+++ b/pages/events/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Jumbotron, Container } from 'reactstrap'
+import { Jumbotron, Container, Button } from 'reactstrap'
 
 import Events from '../../components/Events'
 
@@ -10,19 +10,24 @@ import socialEvents from '../../data/events_social.json'
 export default () => (
   <>
     {style}
-    <Jumbotron className="bg-dark text-white d-flex align-items-center rounded-0">
+    <Jumbotron className='bg-dark text-white d-flex align-items-center rounded-0'>
       <Container style={{ width: '90%' }}>
         <h1>Events</h1>
       </Container>
     </Jumbotron>
     <Container>
-      <Events type="Workshops" direction="right" events={workshopEvents} />
+      <div className='d-flex justify-content-center m-4'>
+        <a href='#Workshops' className='link-unstyled'><Button className='d-none d-md-block btn btn-outline-primary link-unstyled quick-link'>Workshops</Button></a>
+        <a href='#Industry Meetups' className='link-unstyled'><Button className='d-none d-md-block btn btn-outline-primary quick-link'>Industry Meetups</Button></a>
+        <a href='#Social Events' className='link-unstyled'><Button className='d-none d-md-block btn btn-outline-primary quick-link'>Social Events</Button></a>
+      </div>
+      <Events type='Workshops' direction='right' events={workshopEvents} />
       <Events
-        type="Industry Meetups"
-        direction="left"
+        type='Industry Meetups'
+        direction='left'
         events={industryEvents}
       />
-      <Events type="Social Events" direction="right" events={socialEvents} />
+      <Events type='Social Events' direction='right' events={socialEvents} />
     </Container>
   </>
 )
@@ -33,5 +38,10 @@ const style = (
       margin-top: 64px;
       height: 300px;
     }
-  `}</style>
+
+    .quick-link {
+      margin: 0 5px;
+    }
+  `}
+  </style>
 )


### PR DESCRIPTION
…t for usability

You are able to "jump" down the Events page by clicking on different buttons labeled "Workshops",
"Industry Meetups", etc... .

Possible modification for the future to improve maintainability & reduce code duplication:
Insert hotlink buttons programmatically, unfortunately the database hasn't been set up yet and so there is no list of the different event types to fetch.