### PR TITLE
fix nav/link (not found) navigation bug

### DIFF
--- a/src/app/[...not_found]/page.tsx
+++ b/src/app/[...not_found]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation"
+
+export default function NotFoundCatchAll() {
+  notFound()
+}


### PR DESCRIPTION
## Change Summary
**[Briefly summarise the changes that you made. Just high-level stuff]**
"Bug" reported here:
https://github.com/vercel/next.js/issues/60695
https://github.com/vercel/next.js/issues/60408
https://stackoverflow.com/questions/75302340/not-found-page-does-not-work-in-next-js-13

Dynamic routes are resolved after static routes, you can solve it by creating a [dynamic catch-all route](https://beta.nextjs.org/docs/routing/defining-routes#catch-all-segments) using a [...not_found] folder and add it to your app folder.

Important to note that this approach can create problems if you have multiple dynamic routes in your app folder. Dynamic routes in another static folder should be fine however