### PR TITLE
Layout adjustment

### DIFF
--- a/src/app/create-account/page.tsx
+++ b/src/app/create-account/page.tsx
@@ -265,7 +265,7 @@ export default function CreateAccount() {
   }
 
   return (
-    <div className="container grid gap-x-8 gap-y-4 py-8 md:grid-cols-2 md:gap-y-8 lg:gap-x-16">
+    <div className="container grid gap-x-8 gap-y-4 py-12 md:grid-cols-2 md:gap-y-8 lg:gap-x-16">
       <Alert className="md:col-span-2">
         <span className="material-symbols-sharp size-4 text-xl leading-4">mail</span>
         <AlertTitle>New user detected!</AlertTitle>

--- a/src/app/dashboard/(root)/page.tsx
+++ b/src/app/dashboard/(root)/page.tsx
@@ -7,11 +7,11 @@ export default async function Dashboard() {
 
   return (
     <>
-      <div className="container flex flex-wrap gap-x-8 gap-y-4 py-8">
+      <div className="container flex flex-wrap gap-x-8 gap-y-4 py-12">
         <div className="flex-grow">
           <h2 className="font-bold">Hey, {user?.preferred_name}</h2>
           <div className="flex h-full py-8">
-            <p className="self-center">This page is a work in progress. Keep an eye out for updates</p>
+            <p className="self-center">This page is a work in progress. Keep an eye out for updates.</p>
           </div>
         </div>
         <div className="max-w-md">

--- a/src/app/join/layout.tsx
+++ b/src/app/join/layout.tsx
@@ -28,7 +28,7 @@ const Layout = ({ children }: PropsWithChildren) => {
   return (
     <main className="main">
       <TitleText typed>./join</TitleText>
-      <div className="container grid gap-y-8 py-8 md:grid-cols-2 md:gap-x-8">
+      <div className="container grid gap-y-8 py-12 md:grid-cols-2 md:gap-x-8">
         {children}
         <div aria-hidden className="hidden place-items-center font-mono leading-none md:grid">
           <span className="text-8xl">:)</span>

--- a/src/app/projects/(default)/page.tsx
+++ b/src/app/projects/(default)/page.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
 
 export default function ProjectsPage() {
   return (
-    <div className="container">
+    <div className="container py-12">
       <div className="flex flex-col md:flex-row md:gap-12">
         <div className="flex-grow">
           <div className="grid grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] gap-4 py-6">

--- a/src/app/projects/(default)/page.tsx
+++ b/src/app/projects/(default)/page.tsx
@@ -30,13 +30,13 @@ export default function ProjectsPage() {
     <div className="container py-12">
       <div className="flex flex-col md:flex-row md:gap-12">
         <div className="flex-grow">
-          <div className="grid grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] gap-4 py-6">
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] gap-4">
             {projectData.map((project) => (
               <Card key={project.id} project={project} />
             ))}
           </div>
         </div>
-        <div className="mt-6 md:w-1/4">
+        <div className="md:w-1/4">
           <ProjectProcessModal />
         </div>
       </div>


### PR DESCRIPTION
## Change Summary
- Previously, pages had inconsistent padding within the container. This is now resolved, and all pages have uniform padding, especially noticeable when comparing the `/events` and `/projects` pages.

Before:
![image](https://github.com/user-attachments/assets/f1d24849-94d9-421e-aca5-7ca281920f7e)

![image](https://github.com/user-attachments/assets/98e163a6-6572-4a49-85cf-47794d2d7281)

After:
![image](https://github.com/user-attachments/assets/b4d5eab9-b9d6-49e0-8747-f3927242c827)

![image](https://github.com/user-attachments/assets/8d90572d-5974-4cda-bb6e-8fe56257f94e)


### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ ] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**