### PR TITLE
Update Atlassian sponsor link to correct URL

### DIFF
--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -4,7 +4,7 @@
     "alt": "Atlassian logo",
     "logo": "/sponsors/atlassian_logo_dark.svg",
     "dark_logo": "/sponsors/atlassian_logo_dark.svg",
-    "link": "https://janestreet.com/"
+    "link": "https://www.atlassian.com/"
   },
   {
     "name": "Jane Street",


### PR DESCRIPTION
Correct the URL for the Atlassian sponsor link in the configuration.